### PR TITLE
Remove external keyword in menu

### DIFF
--- a/FishExample/sushi-config.yaml
+++ b/FishExample/sushi-config.yaml
@@ -33,4 +33,4 @@ menu:
   Table of Contents: toc.html
   Artifacts Summary: artifacts.html
   Other Resources:
-    "FHIR Spec ": new-tab external {{site.data.fhir.path}}index.html
+    "FHIR Spec ": new-tab {{site.data.fhir.path}}index.html

--- a/FishExampleComplete/sushi-config.yaml
+++ b/FishExampleComplete/sushi-config.yaml
@@ -33,4 +33,4 @@ menu:
   Table of Contents: toc.html
   Artifacts Summary: artifacts.html
   Other Resources:
-    "FHIR Spec ": new-tab external {{site.data.fhir.path}}index.html
+    "FHIR Spec ": new-tab {{site.data.fhir.path}}index.html


### PR DESCRIPTION
Minor change to remove the now deprecated `external` keyword in the menu configuration.